### PR TITLE
Shade groups in Palisade by size

### DIFF
--- a/palisade.c
+++ b/palisade.c
@@ -934,6 +934,10 @@ static void game_changed_state(game_ui *ui, const game_state *oldstate,
 {
 }
 
+typedef struct group_info {
+    int size;
+} group_info;
+
 typedef int dsflags;
 
 struct game_drawstate {
@@ -941,6 +945,8 @@ struct game_drawstate {
     dsflags *grid;
     int k;
     float *group_colour_indexes;
+    group_info **cell_groups; /* length w*h */
+    int *group_size;
 };
 
 #define TILESIZE (ds->tilesize)
@@ -1266,6 +1272,8 @@ static game_drawstate *game_new_drawstate(drawing *dr, const game_state *state)
     ds->grid = NULL;
     ds->k = 0;
     ds->group_colour_indexes = NULL;
+    ds->cell_groups = NULL;
+    ds->group_size = NULL;
 
     return ds;
 }
@@ -1275,6 +1283,8 @@ static void game_free_drawstate(drawing *dr, game_drawstate *ds)
     sfree(ds->grid);
     ds->k = 0;
     sfree(ds->group_colour_indexes);
+    sfree(ds->cell_groups);
+    sfree(ds->group_size);
     sfree(ds);
 }
 
@@ -1405,6 +1415,14 @@ static void game_redraw(drawing *dr, game_drawstate *ds,
         for (int group_size = half_k + 1 ; group_size <= k - 1 ; group_size++) {
             ds->group_colour_indexes[group_size] = HIGHER_COLOUR_GROUP_INDEX(k, group_size);
         }
+    }
+    if (!ds->cell_groups) {
+        snewa(ds->cell_groups, wh);
+        setmem(ds->cell_groups, 0, wh);
+    }
+    if (!ds->group_size) {
+        snewa(ds->group_size, wh);
+        setmem(ds->group_size, 0, wh);
     }
 
     build_dsf(w, h, state->borders, black_border_dsf, true);

--- a/palisade.c
+++ b/palisade.c
@@ -1161,12 +1161,22 @@ enum {
     COL_LINE_MAYBE,
     COL_LINE_NO,
     COL_ERROR,
+    COL_GROUP_2,
+    COL_GROUP_3,
+    COL_GROUP_4,
+    COL_GROUP_5,
+    COL_GROUP_6,
+    COL_GROUP_7,
+    COL_GROUP_8,
+    COL_GROUP_9,
+    COL_GROUP_10,
 
     NCOLOURS
 };
 
 #define COLOUR(i, r, g, b) \
    ((ret[3*(i)+0] = (r)), (ret[3*(i)+1] = (g)), (ret[3*(i)+2] = (b)))
+#define COLOUR255(i, r, g, b) COLOUR(i, r / 255.0F, g / 255.0F, b / 255.0F)
 #define DARKER 0.9F
 
 static float *game_colours(frontend *fe, int *ncolours)
@@ -1187,6 +1197,16 @@ static float *game_colours(frontend *fe, int *ncolours)
            ret[COL_BACKGROUND*3 + 0] * DARKER,
            ret[COL_BACKGROUND*3 + 1] * DARKER,
            ret[COL_BACKGROUND*3 + 2] * DARKER);
+
+    COLOUR255(COL_GROUP_2, 199, 233, 192);
+    COLOUR255(COL_GROUP_3, 161, 217, 155);
+    COLOUR255(COL_GROUP_4, 116, 196, 118);
+    COLOUR255(COL_GROUP_5, 65, 171, 93);
+    COLOUR255(COL_GROUP_6, 158, 202, 225);
+    COLOUR255(COL_GROUP_7, 107, 174, 214);
+    COLOUR255(COL_GROUP_8, 49, 130, 189);
+    COLOUR255(COL_GROUP_9, 8, 81, 156);
+    COLOUR(COL_GROUP_10, 1.0F, 1.0F, 1.0F);
 
     *ncolours = NCOLOURS;
     return ret;

--- a/palisade.c
+++ b/palisade.c
@@ -45,6 +45,7 @@ static char *string(int n, const char *fmt, ...)
 
 enum {
   PREF_CURSOR_MODE,
+  PREF_SHADE_BY_GROUP_SIZES,
   N_PREF_ITEMS
 };
 
@@ -880,6 +881,7 @@ struct game_ui {
     bool show;
 
     bool legacy_cursor;
+    bool shade_by_group_sizes;
 };
 
 static game_ui *new_ui(const game_state *state)
@@ -888,6 +890,7 @@ static game_ui *new_ui(const game_state *state)
     ui->x = ui->y = 1;
     ui->show = getenv_bool("PUZZLES_SHOW_CURSOR", false);
     ui->legacy_cursor = false;
+    ui->shade_by_group_sizes = true;
     return ui;
 }
 
@@ -904,6 +907,11 @@ static config_item *get_prefs(game_ui *ui)
     cfg[PREF_CURSOR_MODE].u.choices.choicekws = ":half:full";
     cfg[PREF_CURSOR_MODE].u.choices.selected = ui->legacy_cursor;
 
+    cfg[PREF_SHADE_BY_GROUP_SIZES].name = "Shade by group sizes";
+    cfg[PREF_SHADE_BY_GROUP_SIZES].kw = "shade-by-group-sizes";
+    cfg[PREF_SHADE_BY_GROUP_SIZES].type = C_BOOLEAN;
+    cfg[PREF_SHADE_BY_GROUP_SIZES].u.boolean.bval = ui->shade_by_group_sizes;
+
     cfg[N_PREF_ITEMS].name = NULL;
     cfg[N_PREF_ITEMS].type = C_END;
 
@@ -913,6 +921,7 @@ static config_item *get_prefs(game_ui *ui)
 static void set_prefs(game_ui *ui, const config_item *cfg)
 {
     ui->legacy_cursor = cfg[PREF_CURSOR_MODE].u.choices.selected;
+    ui->shade_by_group_sizes = cfg[PREF_SHADE_BY_GROUP_SIZES].u.boolean.bval;
 }
 
 static void free_ui(game_ui *ui)

--- a/palisade.c
+++ b/palisade.c
@@ -934,10 +934,6 @@ static void game_changed_state(game_ui *ui, const game_state *oldstate,
 {
 }
 
-typedef struct group_info {
-    int size;
-} group_info;
-
 typedef int dsflags;
 
 struct game_drawstate {
@@ -945,7 +941,6 @@ struct game_drawstate {
     dsflags *grid;
     int k;
     float *group_colour_indexes;
-    group_info **cell_groups; /* length w*h */
     int *group_size;
 };
 
@@ -1272,7 +1267,6 @@ static game_drawstate *game_new_drawstate(drawing *dr, const game_state *state)
     ds->grid = NULL;
     ds->k = 0;
     ds->group_colour_indexes = NULL;
-    ds->cell_groups = NULL;
     ds->group_size = NULL;
 
     return ds;
@@ -1283,106 +1277,8 @@ static void game_free_drawstate(drawing *dr, game_drawstate *ds)
     sfree(ds->grid);
     ds->k = 0;
     sfree(ds->group_colour_indexes);
-    sfree(ds->cell_groups);
     sfree(ds->group_size);
     sfree(ds);
-}
-
-/* Generic queue structure for flooding groups of tiles */
-typedef struct flood_queue_item *flood_queue_item_t;
-typedef struct flood_queue_item {
-    flood_queue_item_t next;
-    int position_i;
-} flood_queue_item;
-typedef struct flood_queue {
-    flood_queue_item *start;
-    flood_queue_item *end;
-} flood_queue;
-
-static void add_to_flood_queue_end(flood_queue *queue, int position_i)
-{
-    flood_queue_item *new_end = snew(struct flood_queue_item);
-    new_end->next = NULL;
-    new_end->position_i = position_i;
-    if (queue->end) {
-        queue->end->next = new_end;
-        queue->end = new_end;
-    } else {
-        queue->start = queue->end = new_end;
-    }
-}
-
-static void remove_from_flood_queue_start(flood_queue *queue)
-{
-    flood_queue_item *next_start = queue->start->next;
-    sfree(queue->start);
-    queue->start = next_start;
-    if (!next_start) {
-        queue->end = NULL;
-    }
-}
-
-/*
-    Flood all connected tiles, starting from position_i. If clear == true, then
-    clear all tiles with the same group as that of position_i, otherwise assign
-    a new group to all neighbouring connected tiles, as long as they're not
-    assigned a group already. (It is a bug to have connected tiles be assigned
-    different groups)
-*/
-static group_info *flood_group(const game_state *state, game_drawstate *ds, int position_i, bool clear) {
-    #define ASSIGNED(position ) \
-        (clear ? (ds->cell_groups[(position)] == NULL) : (ds->cell_groups[(position)] != NULL))
-    if (ASSIGNED(position_i)) {
-        return ds->cell_groups[position_i];
-    }
-    group_info *group;
-    if (clear) {
-        group = ds->cell_groups[position_i];
-    } else {
-        group = snew(struct group_info);
-        group->size = 0;
-    }
-    flood_queue queue = {NULL, NULL};
-    add_to_flood_queue_end(&queue, position_i);
-    int w = state->shared->params.w;
-    while (queue.start) {
-        int current_position_i = queue.start->position_i;
-        remove_from_flood_queue_start(&queue);
-        if (ASSIGNED(current_position_i)) {
-            continue;
-        }
-        if (!clear) {
-            group->size++;
-        }
-        ds->cell_groups[current_position_i] = clear ? NULL : group;
-        // TODO: Should we define a DECOMPOSE_POSITION macro?
-        int c = current_position_i % w;
-        int r = (current_position_i - c) / w;
-        if (state->borders[current_position_i] & DISABLED(BORDER_U)) {
-            // TODO: Should we define a POSITION macro?
-            int new_c = c, new_r = r - 1, new_position_i = new_r * w + new_c;
-            add_to_flood_queue_end(&queue, new_position_i);
-        }
-        if (state->borders[current_position_i] & DISABLED(BORDER_D)) {
-            int new_c = c, new_r = r + 1, new_position_i = new_r * w + new_c;
-            add_to_flood_queue_end(&queue, new_position_i);
-        }
-        if (state->borders[current_position_i] & DISABLED(BORDER_L)) {
-            int new_c = c - 1, new_r = r, new_position_i = new_r * w + new_c;
-            add_to_flood_queue_end(&queue, new_position_i);
-        }
-        if (state->borders[current_position_i] & DISABLED(BORDER_R)) {
-            int new_c = c + 1, new_r = r, new_position_i = new_r * w + new_c;
-            add_to_flood_queue_end(&queue, new_position_i);
-        }
-    }
-    return clear ? NULL : group;
-    #undef ASSIGNED
-}
-
-static int get_group_size(const game_state *state, game_drawstate *ds, int position_i)
-{
-    return flood_group(state, ds, position_i, false)->size;
 }
 
 #define COLOUR(border)                                                  \
@@ -1536,10 +1432,6 @@ static void game_redraw(drawing *dr, game_drawstate *ds,
             ds->group_colour_indexes[group_size] = HIGHER_COLOUR_GROUP_INDEX(k, group_size);
         }
     }
-    if (!ds->cell_groups) {
-        snewa(ds->cell_groups, wh);
-        setmem(ds->cell_groups, 0, wh);
-    }
     if (!ds->group_size) {
         snewa(ds->group_size, wh);
         setmem(ds->group_size, 0, wh);
@@ -1548,14 +1440,6 @@ static void game_redraw(drawing *dr, game_drawstate *ds,
     build_dsf(w, h, state->borders, black_border_dsf, true);
     build_dsf(w, h, state->borders, yellow_border_dsf, false);
 
-    /*
-        Do 2 passes: first figure what tiles borders have changed, and update
-        the groups, and then draw the tiles.
-        The reason is that a tile might not have changed borders, but they might
-        have changed groups due to another tile changing borders.
-    */
-    dsflags *new_flags = dupmem(ds->grid, wh);
-    /* Border & group checking phase */
     for (r = 0; r < h; ++r)
         for (c = 0; c < w; ++c) {
             int i = r * w + c, clue = state->shared->clues[i], flags, dir;
@@ -1613,30 +1497,8 @@ static void game_redraw(drawing *dr, game_drawstate *ds,
 
                     flags |= BORDER_ERROR(BORDER(dir));
             }
-            new_flags[i] = flags;
-            if (flags != ds->grid[i]) {
-                flood_group(state, ds, i, true);
-                if (r + 1 < h) {
-                    flood_group(state, ds, (r + 1)*w + c, true);
-                }
-                if (r - 1 >= 0) {
-                    flood_group(state, ds, (r - 1)*w + c, true);
-                }
-                if (c + 1 < w) {
-                    flood_group(state, ds, r*w + (c + 1), true);
-                }
-                if (c - 1 >= 0) {
-                    flood_group(state, ds, r*w + (c - 1), true);
-                }
-            }
-        }
 
-    /* Redrawing phase if the borders and/or group changed */
-    for (r = 0; r < h; ++r)
-        for (c = 0; c < w; ++c) {
-            int i = r * w + c, clue = state->shared->clues[i], flags = new_flags[i];
-
-            int group_size = ui->shade_by_group_sizes ? get_group_size(state, ds, i) : 0;
+            int group_size = ui->shade_by_group_sizes ? dsf_size(yellow_border_dsf, i) : 0;
             if (flags == ds->grid[i] && group_size == ds->group_size[i]) continue;
             ds->grid[i] = flags;
             ds->group_size[i] = group_size;


### PR DESCRIPTION
I've been recently playing Palisade, and one issue I have with the UI is that the yellow borders can make it very hard to discern the incomplete connected regions, as yellow doesn't clash enough with grey.

A simple solution might be to choose a more contrasting colour, but I also came up with a different change: shading the connected regions so that you can see the size of them in a quick glance. When you're playing with size 10 regions it might be tedious to check if you could merge them or not. So I've come up with the following: use green shades for sizes 2 up to region/2, blue shades for region/2+0.5 up to region-1, and white for completed regions. This makes it much easier to spot the regions, especially in a 30x30 board that I usually play.

![image](https://github.com/user-attachments/assets/9b072c98-d001-40a0-8ceb-f569781a5de0)

For smaller puzzle sizes we use a smaller set of colours, but still green for less than region/2 and blue otherwise

![image](https://github.com/user-attachments/assets/24031d57-d4ca-4efa-8c12-27562ecacee2)

For bigger puzzles we reuse colours

I've put this behind a setting so that it can be opt-in or opt-out, if people find it jarring.

![image](https://github.com/user-attachments/assets/14093a36-fcbd-4096-97c1-953cc578520d)
