### PR TITLE
Toggle all undecided tiles in Palisade on select

### DIFF
--- a/palisade.c
+++ b/palisade.c
@@ -1059,7 +1059,34 @@ static char *interpret_move(const game_state *state, game_ui *ui,
             return MOVE_UI_UPDATE;
         }
 
-        /* clicks on square corners and centers do nothing */
+        /* cursor selects on tiles toglle all undecided sides on or off */
+        if ((px == py) && (px == 1)) {
+            int changes = 0;
+            char *result = string(0, ""), *last_result = NULL;
+            int first, second;
+            for (int j = 0 ; j < 4 ; j++) {
+                if (!(state->borders[i] & BORDER(j)) && !(state->borders[i] & DISABLED(BORDER(j)))) {
+                    first = BORDER(j);
+                    second = BORDER(FLIP(j));
+                    if (button == CURSOR_SELECT2) {
+                        first = DISABLED(first);
+                        second = DISABLED(second);
+                    }
+
+                    changes++;
+                    last_result = result;
+                    result = string(changes * 20, "%sF%d,%d,%dF%d,%d,%d", result, gx, gy, first, gx + dx[j], gy + dy[j], second);
+                    sfree(last_result);
+                }
+            }
+            if (changes == 0) {
+                sfree(result);
+                return NULL;
+            }
+            return result;
+        }
+
+        /* clicks on square corners do nothing */
         if (px == py)
             return MOVE_NO_EFFECT;
 


### PR DESCRIPTION
When selecting a tile with the cursor, toggle all undecided sides on or off, depending on if it's the primary or secondary button.

This makes it easier to toggle multiple sides for a tile at once

When a tile has all borders determined:
![image](https://github.com/user-attachments/assets/3b494aba-cb9b-4af5-a90e-086033d58ecb)
Pressing `[Space]` marks the undecided ones as disabled:
![image](https://github.com/user-attachments/assets/daa785b3-e771-4a20-b5d4-e708a081e69a)

When a tile has all its connected sides determined:
![image](https://github.com/user-attachments/assets/5836cf6e-0f00-4a1a-8c6d-d344093db792)
Pressing `[Enter]` marks the undecided ones as borders:
![image](https://github.com/user-attachments/assets/5c76a6ae-437a-40ee-8fcb-1de585cbc112)
