### PR TITLE
Interactive Windows game creation

### DIFF
--- a/midend.c
+++ b/midend.c
@@ -541,6 +541,39 @@ void midend_new_game(midend *me)
     }
 }
 
+char *get_new_game_desc(midend *me, char *seedstr, char **aux)
+{
+
+    if (me->genmode == GOT_NOTHING) {
+        /*
+         * Generate a new random seed. 15 digits comes to about
+         * 48 bits, which should be more than enough.
+         *
+         * I'll avoid putting a leading zero on the number,
+         * just in case it confuses anybody who thinks it's
+         * processed as an integer rather than a string.
+         */
+        seedstr[15] = '\0';
+        seedstr[0] = '1' + (char)random_upto(me->random, 9);
+        for (int i = 1; i < 15; i++) {
+            seedstr[i] = '0' + (char)random_upto(me->random, 10);
+        }
+    }
+
+    random_state *rs = random_new(seedstr, strlen(seedstr));
+    /*
+     * If this midend has been instantiated without providing a
+     * drawing API, it is non-interactive. This means that it's
+     * being used for bulk game generation, and hence we should
+     * pass the non-interactive flag to new_desc.
+     */
+    char *desc = me->ourgame->new_desc(me->params, rs, aux, (me->drawing != NULL));
+    assert_printable_ascii(desc);
+    random_free(rs);
+
+    return desc;
+}
+
 void midend_create_game(midend *me)
 {
     me->newgame_undo.len = 0;
@@ -569,52 +602,25 @@ void midend_create_game(midend *me)
     assert(me->nstates == 0);
 
     if (me->genmode == GOT_DESC) {
-	me->genmode = GOT_NOTHING;
+        me->genmode = GOT_NOTHING;
     } else {
-        random_state *rs;
-
         if (me->genmode == GOT_SEED) {
             me->genmode = GOT_NOTHING;
         } else {
-            /*
-             * Generate a new random seed. 15 digits comes to about
-             * 48 bits, which should be more than enough.
-             * 
-             * I'll avoid putting a leading zero on the number,
-             * just in case it confuses anybody who thinks it's
-             * processed as an integer rather than a string.
-             */
-            char newseed[16];
-            int i;
-            newseed[15] = '\0';
-            newseed[0] = '1' + (char)random_upto(me->random, 9);
-            for (i = 1; i < 15; i++)
-                newseed[i] = '0' + (char)random_upto(me->random, 10);
             sfree(me->seedstr);
-            me->seedstr = dupstr(newseed);
-
-	    if (me->curparams)
-		me->ourgame->free_params(me->curparams);
-	    me->curparams = me->ourgame->dup_params(me->params);
+            me->seedstr = snewn(16, char);
+            if (me->curparams) {
+                me->ourgame->free_params(me->curparams);
+            }
+            me->curparams = me->ourgame->dup_params(me->params);
         }
 
-	sfree(me->desc);
-	sfree(me->privdesc);
+    	sfree(me->desc);
+    	sfree(me->privdesc);
         sfree(me->aux_info);
-	me->aux_info = NULL;
-
-        rs = random_new(me->seedstr, strlen(me->seedstr));
-	/*
-	 * If this midend has been instantiated without providing a
-	 * drawing API, it is non-interactive. This means that it's
-	 * being used for bulk game generation, and hence we should
-	 * pass the non-interactive flag to new_desc.
-	 */
-        me->desc = me->ourgame->new_desc(me->curparams, rs,
-					 &me->aux_info, (me->drawing != NULL));
-	assert_printable_ascii(me->desc);
-	me->privdesc = NULL;
-        random_free(rs);
+        me->aux_info = NULL;
+        me->desc = get_new_game_desc(me, me->seedstr, &me->aux_info);
+        me->privdesc = NULL;
     }
 
     ensure(me);

--- a/midend.c
+++ b/midend.c
@@ -826,7 +826,7 @@ void midend_create_game_inner(midend *me, new_game_desc_args *args, bool make_co
             sfree(me->aux_info);
             me->aux_info = args->aux;
         }
-        if (make_copies) {
+        if (make_copies && me->aux_info) {
             me->aux_info = dupstr(me->aux_info);
         }
     }

--- a/midend.c
+++ b/midend.c
@@ -579,6 +579,13 @@ typedef struct new_game_desc_args {
     char *desc;
 } new_game_desc_args;
 
+void new_game_async_attempt(midend *me, new_game_desc_args *args)
+{
+    midend_create_game_inner(me, args);
+    midend_solve(me);
+    midend_redraw(me);
+}
+
 void new_game_async_complete(midend *me, new_game_desc_args *args)
 {
     midend_create_game_inner(me, args);
@@ -683,7 +690,7 @@ void deserialise_new_game_desc_args(midend *me, new_game_desc_args *args, char *
     args->desc = deserialise_string(&serialised);
 }
 
-char *get_new_game_desc(midend *me, new_game_desc_args *args)
+char *get_new_game_desc(midend *me, new_game_desc_args *args, bool iterative, void *iterative_arg)
 {
     random_state *rs = random_new(args->seedstr, strlen(args->seedstr));
     /*
@@ -692,7 +699,29 @@ char *get_new_game_desc(midend *me, new_game_desc_args *args)
      * being used for bulk game generation, and hence we should
      * pass the non-interactive flag to new_desc.
      */
-    args->desc = me->ourgame->new_desc(args->params, rs, &args->aux, args->interactive);
+    if (me->ourgame->attempt_new_desc) {
+        desc_data dd = {args->params, rs, args->interactive, args->aux};
+        me->ourgame->initialise_desc_data(&dd);
+
+        bool solved = false;
+        int attempts = 0;
+        while (!solved) {
+            solved = me->ourgame->attempt_new_desc(&dd);
+            attempts++;
+            args->desc = dd.desc;
+            args->aux = dd.aux;
+            if (iterative) {
+                new_game_attempt(iterative_arg, me, args, attempts, solved);
+            }
+        }
+        me->ourgame->destroy_desc_data(&dd, true);
+
+        args->aux = dd.aux;
+        args->desc = dd.desc;
+    } else {
+        args->desc = me->ourgame->new_desc(args->params, rs, &args->aux, args->interactive);
+    }
+
     assert_printable_ascii(args->desc);
     random_free(rs);
 
@@ -715,7 +744,7 @@ void midend_create_game(midend *me)
             sfree(args.seedstr);
             args.seedstr = get_new_seedstr(me, NULL);
         }
-        args.desc = get_new_game_desc(me, &args);
+        args.desc = get_new_game_desc(me, &args, false, NULL);
     }
     midend_create_game_inner(me, &args);
 }
@@ -754,20 +783,28 @@ void midend_create_game_inner(midend *me, new_game_desc_args *args)
         if (me->genmode == GOT_SEED) {
             me->genmode = GOT_NOTHING;
         } else {
-            sfree(me->seedstr);
-            me->seedstr = args->seedstr;
-            if (me->curparams) {
-                me->ourgame->free_params(me->curparams);
+            if (me->seedstr != args->seedstr) {
+                sfree(me->seedstr);
+                me->seedstr = args->seedstr;
             }
-            me->curparams = args->params;
+            if (me->curparams != args->params) {
+                if (me->curparams) {
+                    me->ourgame->free_params(me->curparams);
+                }
+                me->curparams = args->params;
+            }
         }
 
-    	sfree(me->desc);
-    	sfree(me->privdesc);
-        sfree(me->aux_info);
-        me->aux_info = args->aux;
-        me->desc = args->desc;
-        me->privdesc = NULL;
+        if (me->desc != args->desc) {
+            sfree(me->desc);
+            me->desc = args->desc;
+            sfree(me->privdesc);
+            me->privdesc = NULL;
+        }
+        if (me->aux_info != args->aux) {
+            sfree(me->aux_info);
+            me->aux_info = args->aux;
+        }
     }
 
     ensure(me);

--- a/midend.c
+++ b/midend.c
@@ -749,7 +749,7 @@ void midend_create_game(midend *me)
         me->seedstr ? dupstr(me->seedstr) : NULL,
         NULL,
         me->drawing != NULL,
-        NULL
+        me->genmode == GOT_DESC ? me->desc : NULL,
     };
     if (me->genmode != GOT_DESC) {
         if (me->genmode == GOT_NOTHING) {

--- a/midend.c
+++ b/midend.c
@@ -567,7 +567,7 @@ char *get_new_seedstr(midend *me, char *seedstr)
 }
 
 void midend_create_game(midend *me);
-void midend_create_game_inner(midend *me, new_game_desc_args *args);
+void midend_create_game_inner(midend *me, new_game_desc_args *args, bool make_copies);
 
 typedef struct new_game_desc_args {
     int game_id;
@@ -581,14 +581,17 @@ typedef struct new_game_desc_args {
 
 void new_game_async_attempt(midend *me, new_game_desc_args *args)
 {
-    midend_create_game_inner(me, args);
+    midend_create_game_inner(me, args, true);
     midend_solve(me);
     midend_redraw(me);
 }
 
 void new_game_async_complete(midend *me, new_game_desc_args *args)
 {
-    midend_create_game_inner(me, args);
+    if (!args->desc) {
+        return;
+    }
+    midend_create_game_inner(me, args, false);
     midend_redraw(me);
     new_game_finished(me->drawing);
 }
@@ -596,7 +599,6 @@ void new_game_async_complete(midend *me, new_game_desc_args *args)
 void midend_new_game(midend *me)
 {
     if (me->nstates > 0 && (me->genmode == GOT_NOTHING || me->genmode == GOT_SEED)) {
-        new_game_started(me->drawing);
         new_game_desc_args *args = snew(new_game_desc_args);
         args->game_id = get_game_id(me);
         args->genmode = me->genmode;
@@ -711,18 +713,28 @@ char *get_new_game_desc(midend *me, new_game_desc_args *args, bool iterative, vo
             args->desc = dd.desc;
             args->aux = dd.aux;
             if (iterative) {
-                new_game_attempt(iterative_arg, me, args, attempts, solved);
+                bool continue_iterating = new_game_attempt(iterative_arg, me, args, attempts, solved);
+                if (!continue_iterating) {
+                    break;
+                }
             }
         }
-        me->ourgame->destroy_desc_data(&dd, true);
+        me->ourgame->destroy_desc_data(&dd, solved);
 
-        args->aux = dd.aux;
-        args->desc = dd.desc;
+        if (solved) {
+            args->aux = dd.aux;
+            args->desc = dd.desc;
+        } else {
+            args->aux = NULL;
+            args->desc = NULL;
+        }
     } else {
         args->desc = me->ourgame->new_desc(args->params, rs, &args->aux, args->interactive);
     }
 
-    assert_printable_ascii(args->desc);
+    if (args->desc) {
+        assert_printable_ascii(args->desc);
+    }
     random_free(rs);
 
     return args->desc;
@@ -746,10 +758,10 @@ void midend_create_game(midend *me)
         }
         args.desc = get_new_game_desc(me, &args, false, NULL);
     }
-    midend_create_game_inner(me, &args);
+    midend_create_game_inner(me, &args, false);
 }
 
-void midend_create_game_inner(midend *me, new_game_desc_args *args)
+void midend_create_game_inner(midend *me, new_game_desc_args *args, bool make_copies)
 {
     me->newgame_undo.len = 0;
     if (me->newgame_can_store_undo) {
@@ -787,11 +799,17 @@ void midend_create_game_inner(midend *me, new_game_desc_args *args)
                 sfree(me->seedstr);
                 me->seedstr = args->seedstr;
             }
+            if (make_copies) {
+                me->seedstr = dupstr(me->seedstr);
+            }
             if (me->curparams != args->params) {
                 if (me->curparams) {
                     me->ourgame->free_params(me->curparams);
                 }
                 me->curparams = args->params;
+            }
+            if (make_copies) {
+                me->curparams = me->ourgame->dup_params(me->curparams);
             }
         }
 
@@ -801,9 +819,15 @@ void midend_create_game_inner(midend *me, new_game_desc_args *args)
             sfree(me->privdesc);
             me->privdesc = NULL;
         }
+        if (make_copies) {
+            me->desc = dupstr(me->desc);
+        }
         if (me->aux_info != args->aux) {
             sfree(me->aux_info);
             me->aux_info = args->aux;
+        }
+        if (make_copies) {
+            me->aux_info = dupstr(me->aux_info);
         }
     }
 

--- a/midend.c
+++ b/midend.c
@@ -35,6 +35,8 @@ struct midend_serialise_buf_read_ctx {
     int len, pos;
 };
 
+enum Genmode { GOT_SEED, GOT_DESC, GOT_NOTHING };
+
 struct midend {
     frontend *frontend;
     random_state *random;
@@ -68,7 +70,7 @@ struct midend {
      */
     char *desc, *privdesc, *seedstr;
     char *aux_info;
-    enum { GOT_SEED, GOT_DESC, GOT_NOTHING } genmode;
+    Genmode genmode;
 
     int nstates, statesize, statepos;
     struct midend_state_entry *states;
@@ -528,53 +530,197 @@ static bool midend_serialise_buf_read(void *ctx, void *buf, int len)
     return true;
 }
 
+int get_game_id(midend *me)
+{
+    int game_id = -1;
+    #ifdef COMBINED
+        for (int i = 0 ; i < gamecount ; i++) {
+            if (me->ourgame == gamelist[i]) {
+                game_id = i;
+                break;
+            }
+        }
+        assert(game_id > -1 && "Could not find game id");
+    #endif
+    return game_id;
+}
+
+char *get_new_seedstr(midend *me, char *seedstr)
+{
+    if (!seedstr) {
+        seedstr = snewn(16, char);
+    }
+    /*
+     * Generate a new random seed. 15 digits comes to about
+     * 48 bits, which should be more than enough.
+     *
+     * I'll avoid putting a leading zero on the number,
+     * just in case it confuses anybody who thinks it's
+     * processed as an integer rather than a string.
+     */
+    seedstr[15] = '\0';
+    seedstr[0] = '1' + (char)random_upto(me->random, 9);
+    for (int i = 1; i < 15; i++) {
+        seedstr[i] = '0' + (char)random_upto(me->random, 10);
+    }
+    return seedstr;
+}
+
 void midend_create_game(midend *me);
+void midend_create_game_inner(midend *me, new_game_desc_args *args);
+
+typedef struct new_game_desc_args {
+    int game_id;
+    Genmode genmode;
+    game_params *params;
+    char *seedstr;
+    char *aux;
+    bool interactive;
+    char *desc;
+} new_game_desc_args;
+
+void new_game_async_complete(midend *me, new_game_desc_args *args)
+{
+    midend_create_game_inner(me, args);
+    midend_redraw(me);
+    new_game_finished(me->drawing);
+}
 
 void midend_new_game(midend *me)
 {
-    if (me->nstates > 0) {
+    if (me->nstates > 0 && (me->genmode == GOT_NOTHING || me->genmode == GOT_SEED)) {
         new_game_started(me->drawing);
-    }
-    midend_create_game(me);
-    if (me->nstates > 0) {
-        new_game_finished(me->drawing);
+        new_game_desc_args *args = snew(new_game_desc_args);
+        args->game_id = get_game_id(me);
+        args->genmode = me->genmode;
+        args->params = me->ourgame->dup_params(me->params);
+        if (me->genmode == GOT_NOTHING) {
+            args->seedstr = get_new_seedstr(me, NULL);
+        } else {
+            args->seedstr = dupstr(me->seedstr);
+        }
+        args->aux = NULL;
+        args->interactive = me->drawing != NULL;
+        args->desc = NULL;
+        get_new_game_desc_async(me, me->frontend, args);
+    } else {
+        midend_create_game(me);
     }
 }
 
-char *get_new_game_desc(midend *me, char *seedstr, char **aux)
+char *serialise_new_game_desc_args(midend *me, new_game_desc_args *args)
 {
+    char *serialised_params = me->ourgame->encode_params(args->params, true);
+    int serialised_params_len = strlen(serialised_params);
+    int seedstr_len = args->seedstr ? strlen(args->seedstr) : 0;
+    int aux_len = args->aux ? strlen(args->aux) : 0;
+    int desc_len = args->desc ? strlen(args->desc) : 0;
+    char *serialised = snewn(
+        11
+        + 11
+        + 11 + serialised_params_len
+        + 11 + seedstr_len
+        + 11 + aux_len
+        + 11
+        + 11 + desc_len
+        + 1,
+        char
+    );
+    sprintf(
+        serialised, "%d:%d:%d:%s:%d:%s:%d:%s:%d:%d:%s",
+        args->game_id,
+        args->genmode,
+        strlen(serialised_params), serialised_params,
+        seedstr_len, args->seedstr ? args->seedstr : "",
+        aux_len, args->aux ? args->aux : "",
+        args->interactive,
+        desc_len, args->desc ? args->desc : ""
+    );
+    sfree(serialised_params);
+    return serialised;
+}
 
-    if (me->genmode == GOT_NOTHING) {
-        /*
-         * Generate a new random seed. 15 digits comes to about
-         * 48 bits, which should be more than enough.
-         *
-         * I'll avoid putting a leading zero on the number,
-         * just in case it confuses anybody who thinks it's
-         * processed as an integer rather than a string.
-         */
-        seedstr[15] = '\0';
-        seedstr[0] = '1' + (char)random_upto(me->random, 9);
-        for (int i = 1; i < 15; i++) {
-            seedstr[i] = '0' + (char)random_upto(me->random, 10);
-        }
+int deserialise_int(char **serialised_ptr)
+{
+    char *serialised = *serialised_ptr;
+    int number;
+    int read_count = sscanf(serialised, "%d:", &number);
+    serialised += read_count + 1;
+    *serialised_ptr = serialised;
+    return number;
+}
+
+char *deserialise_string(char **serialised_ptr)
+{
+    char *serialised = *serialised_ptr;
+    int len;
+    int read_count = sscanf(serialised, "%d:", &len);
+    serialised += read_count + 1;
+    char *result;
+    if (len == 0) {
+        result = NULL;
+    } else {
+        result = snewn(len + 1, char);
+        strncpy(result, serialised, len);
+        result[len] = '\0';
     }
+    serialised += len + 1;
+    *serialised_ptr = serialised;
+    return result;
+}
 
-    random_state *rs = random_new(seedstr, strlen(seedstr));
+void deserialise_new_game_desc_args(midend *me, new_game_desc_args *args, char *serialised)
+{
+    args->game_id = deserialise_int(&serialised);
+    args->genmode = deserialise_int(&serialised);
+    char *serialised_params = deserialise_string(&serialised);
+    args->params = me->ourgame->default_params();
+    me->ourgame->decode_params(args->params, serialised_params);
+    sfree(serialised_params);
+    args->seedstr = deserialise_string(&serialised);
+    args->aux = deserialise_string(&serialised);
+    args->interactive = deserialise_int(&serialised) != 0;
+    args->desc = deserialise_string(&serialised);
+}
+
+char *get_new_game_desc(midend *me, new_game_desc_args *args)
+{
+    random_state *rs = random_new(args->seedstr, strlen(args->seedstr));
     /*
      * If this midend has been instantiated without providing a
      * drawing API, it is non-interactive. This means that it's
      * being used for bulk game generation, and hence we should
      * pass the non-interactive flag to new_desc.
      */
-    char *desc = me->ourgame->new_desc(me->params, rs, aux, (me->drawing != NULL));
-    assert_printable_ascii(desc);
+    args->desc = me->ourgame->new_desc(args->params, rs, &args->aux, args->interactive);
+    assert_printable_ascii(args->desc);
     random_free(rs);
 
-    return desc;
+    return args->desc;
 }
 
 void midend_create_game(midend *me)
+{
+    new_game_desc_args args = {
+        get_game_id(me),
+        me->genmode,
+        me->ourgame->dup_params(me->curparams ? me->curparams : me->params),
+        me->seedstr ? dupstr(me->seedstr) : NULL,
+        NULL,
+        me->drawing != NULL,
+        NULL
+    };
+    if (me->genmode != GOT_DESC) {
+        if (me->genmode == GOT_NOTHING) {
+            sfree(args.seedstr);
+            args.seedstr = get_new_seedstr(me, NULL);
+        }
+        args.desc = get_new_game_desc(me, &args);
+    }
+    midend_create_game_inner(me, &args);
+}
+
+void midend_create_game_inner(midend *me, new_game_desc_args *args)
 {
     me->newgame_undo.len = 0;
     if (me->newgame_can_store_undo) {
@@ -601,6 +747,7 @@ void midend_create_game(midend *me)
 
     assert(me->nstates == 0);
 
+    me->genmode = args->genmode;
     if (me->genmode == GOT_DESC) {
         me->genmode = GOT_NOTHING;
     } else {
@@ -608,18 +755,18 @@ void midend_create_game(midend *me)
             me->genmode = GOT_NOTHING;
         } else {
             sfree(me->seedstr);
-            me->seedstr = snewn(16, char);
+            me->seedstr = args->seedstr;
             if (me->curparams) {
                 me->ourgame->free_params(me->curparams);
             }
-            me->curparams = me->ourgame->dup_params(me->params);
+            me->curparams = args->params;
         }
 
     	sfree(me->desc);
     	sfree(me->privdesc);
         sfree(me->aux_info);
-        me->aux_info = NULL;
-        me->desc = get_new_game_desc(me, me->seedstr, &me->aux_info);
+        me->aux_info = args->aux;
+        me->desc = args->desc;
         me->privdesc = NULL;
     }
 

--- a/midend.c
+++ b/midend.c
@@ -528,7 +528,20 @@ static bool midend_serialise_buf_read(void *ctx, void *buf, int len)
     return true;
 }
 
+void midend_create_game(midend *me);
+
 void midend_new_game(midend *me)
+{
+    if (me->nstates > 0) {
+        new_game_started(me->drawing);
+    }
+    midend_create_game(me);
+    if (me->nstates > 0) {
+        new_game_finished(me->drawing);
+    }
+}
+
+void midend_create_game(midend *me)
 {
     me->newgame_undo.len = 0;
     if (me->newgame_can_store_undo) {

--- a/midend.c
+++ b/midend.c
@@ -581,6 +581,9 @@ typedef struct new_game_desc_args {
 
 void new_game_async_attempt(midend *me, new_game_desc_args *args)
 {
+    if (!args->desc || args->desc[0] == '\0') {
+        return;
+    }
     midend_create_game_inner(me, args, true);
     midend_solve(me);
     midend_redraw(me);

--- a/palisade.c
+++ b/palisade.c
@@ -751,8 +751,6 @@ static void destroy_desc_data(desc_data *dd, bool keep_outputs)
     if (!keep_outputs) {
         sfree(gdd->desc);
         sfree(gdd->soln);
-    } else {
-        dd->desc = sresize(dd->desc, strlen(dd->desc) + 1, char);
     }
     sfree(gdd);
     dd->game_desc_data = NULL;
@@ -769,7 +767,7 @@ static char *new_game_desc(const game_params *params, random_state *rs,
 
     *aux = dd.aux;
 
-    return dd.desc;
+    return sresize(dd.desc, strlen(dd.desc) + 1, char);
 }
 
 static const char *validate_desc(const game_params *params, const char *desc)
@@ -1599,4 +1597,7 @@ const struct game thegame = {
     true,                                     /* wants_statusbar */
     false, NULL,                       /* timing_state */
     0,                                         /* flags */
+    initialise_desc_data,
+    attempt_new_desc,
+    destroy_desc_data
 };

--- a/palisade.c
+++ b/palisade.c
@@ -751,6 +751,8 @@ static void destroy_desc_data(desc_data *dd, bool keep_outputs)
     if (!keep_outputs) {
         sfree(gdd->desc);
         sfree(gdd->soln);
+        dd->desc = NULL;
+        dd->aux = NULL;
     }
     sfree(gdd);
     dd->game_desc_data = NULL;

--- a/palisade.c
+++ b/palisade.c
@@ -660,6 +660,8 @@ static void initialise_desc_data(desc_data *dd)
         gdd->shuf[i] = i;
     }
     xshuffle(gdd->shuf, wh, gdd->rs);
+
+    dd->desc = gdd->desc = snewn(wh + 1, char);
 }
 
 static bool attempt_new_desc(desc_data *dd)
@@ -697,7 +699,45 @@ static bool attempt_new_desc(desc_data *dd)
     scopy(scratch_borders, rim, wh);
     dsf_free(dsf);
 
-    return solver(dd->params, numbers, scratch_borders);
+    bool solved = solver(dd->params, numbers, scratch_borders);
+
+    /* Remove any unnecessary clues */
+    if (solved) {
+        for (int i = 0; i < wh; ++i) {
+            int j = shuf[i];
+            clue copy = numbers[j];
+
+            scopy(scratch_borders, rim, wh);
+            numbers[j] = EMPTY; /* strip away unnecssary clues */
+            if (!solver(gdd->params, numbers, scratch_borders)) {
+                numbers[j] = copy;
+            }
+        }
+
+        numbers[wh] = '\0';
+    }
+
+    /* Convert the clues into a description */
+    char *p = gdd->desc;
+    int r = 0;
+    for (int i = 0; i < wh; ++i) {
+        if (numbers[i] != EMPTY) {
+            while (r) {
+                while (r > 26) {
+                    *p++ = 'z';
+                    r -= 26;
+                }
+                *p++ = 'a'-1 + r;
+                r = 0;
+            }
+            *p++ = '0' + numbers[i];
+        } else {
+            ++r;
+        }
+    }
+    *p++ = '\0';
+
+    return solved;
 }
 
 static char *new_game_desc(const game_params *params, random_state *rs,
@@ -717,43 +757,15 @@ static char *new_game_desc(const game_params *params, random_state *rs,
     int *shuf = gdd->shuf;
 
     while (!attempt_new_desc(&dd)) {}
-
-    for (int i = 0; i < wh; ++i) {
-        int j = shuf[i];
-        clue copy = numbers[j];
-
-        scopy(scratch_borders, rim, wh);
-        numbers[j] = EMPTY; /* strip away unnecssary clues */
-        if (!solver(params, numbers, scratch_borders))
-            numbers[j] = copy;
-    }
-
-    numbers[wh] = '\0';
+    char *output = sresize(gdd->desc, strlen(gdd->desc) + 1, char);
 
     sfree(scratch_borders);
     sfree(rim);
     sfree(shuf);
-
-    char *output = snewn(wh + 1, char), *p = output;
-
-    int r = 0;
-    for (int i = 0; i < wh; ++i) {
-        if (numbers[i] != EMPTY) {
-            while (r) {
-                while (r > 26) {
-                    *p++ = 'z';
-                    r -= 26;
-                }
-                *p++ = 'a'-1 + r;
-                r = 0;
-            }
-            *p++ = '0' + numbers[i];
-        } else ++r;
-    }
-    *p++ = '\0';
-
     sfree(numbers);
-    return sresize(output, p - output, char);
+    sfree(gdd);
+
+    return output;
 }
 
 static const char *validate_desc(const game_params *params, const char *desc)

--- a/palisade.c
+++ b/palisade.c
@@ -740,32 +740,36 @@ static bool attempt_new_desc(desc_data *dd)
     return solved;
 }
 
+static void destroy_desc_data(desc_data *dd, bool keep_outputs)
+{
+    game_desc_data *gdd = dd->game_desc_data;
+
+    sfree(gdd->scratch_borders);
+    sfree(gdd->rim);
+    sfree(gdd->shuf);
+    sfree(gdd->numbers);
+    if (!keep_outputs) {
+        sfree(gdd->desc);
+        sfree(gdd->soln);
+    } else {
+        dd->desc = sresize(dd->desc, strlen(dd->desc) + 1, char);
+    }
+    sfree(gdd);
+    dd->game_desc_data = NULL;
+}
+
 static char *new_game_desc(const game_params *params, random_state *rs,
                            char **aux, bool interactive)
 {
-    int w = params->w, h = params->h, wh = w*h, k = params->k;
-
     desc_data dd = {params, rs, interactive, *aux};
     initialise_desc_data(&dd);
-    game_desc_data *gdd = dd.game_desc_data;
-
-    char *numbers = gdd->numbers;
-    borderflag *rim = gdd->rim;
-    borderflag *scratch_borders = gdd->scratch_borders;
-
-    char *soln = gdd->soln;
-    int *shuf = gdd->shuf;
 
     while (!attempt_new_desc(&dd)) {}
-    char *output = sresize(gdd->desc, strlen(gdd->desc) + 1, char);
+    destroy_desc_data(&dd, true);
 
-    sfree(scratch_borders);
-    sfree(rim);
-    sfree(shuf);
-    sfree(numbers);
-    sfree(gdd);
+    *aux = dd.aux;
 
-    return output;
+    return dd.desc;
 }
 
 static const char *validate_desc(const game_params *params, const char *desc)

--- a/palisade.c
+++ b/palisade.c
@@ -625,53 +625,100 @@ static void init_borders(int w, int h, borderflag *borders)
 
 #define xshuffle(ptr, len, rs) shuffle((ptr), (len), sizeof (ptr)[0], (rs))
 
+typedef struct game_desc_data {
+    const game_params *params;
+    random_state *rs;
+    clue *numbers;
+    borderflag *rim;
+    borderflag *scratch_borders;
+    char *soln;
+    int *shuf;
+    char *desc;
+} game_desc_data;
+
+static void initialise_desc_data(desc_data *dd)
+{
+    game_desc_data *gdd = dd->game_desc_data = snew(game_desc_data);
+
+    int w = dd->params->w, h = dd->params->h, wh = w * h, k = dd->params->k;
+
+    gdd->params = dd->params;
+    gdd->rs = dd->rs;
+
+    gdd->numbers = snewn(wh + 1, clue);
+    gdd->rim = snewn(wh, borderflag);
+    init_borders(w, h, gdd->rim);
+    gdd->scratch_borders = snewn(wh, borderflag);
+
+    dd->aux = gdd->soln = snewa(dd->aux, wh + 2);
+    assert (!('@' & BORDER_MASK));
+    gdd->soln[0] = 'S';
+    gdd->soln[wh + 1] = '\0';
+
+    gdd->shuf = snewn(wh, int);
+    for (int i = 0; i < wh; ++i) {
+        gdd->shuf[i] = i;
+    }
+    xshuffle(gdd->shuf, wh, gdd->rs);
+}
+
+static bool attempt_new_desc(desc_data *dd)
+{
+    game_desc_data *gdd = dd->game_desc_data;
+
+    char *numbers = gdd->numbers;
+    borderflag *rim = gdd->rim;
+    borderflag *scratch_borders = gdd->scratch_borders;
+
+    char *soln = gdd->soln;
+    int *shuf = gdd->shuf;
+    DSF *dsf = NULL;
+
+    int w = dd->params->w, h = dd->params->h, wh = w * h, k = dd->params->k;
+
+    setmem(soln + 1, '@', wh);
+
+    dsf = divvy_rectangle(w, h, k, gdd->rs);
+
+    for (int r = 0; r < h; ++r) {
+        for (int c = 0; c < w; ++c) {
+            int i = r * w + c, dir;
+            numbers[i] = 0;
+            for (dir = 0; dir < 4; ++dir) {
+                int rr = r + dy[dir], cc = c + dx[dir], ii = rr * w + cc;
+                if (OUT_OF_BOUNDS(cc, rr, w, h) || !dsf_equivalent(dsf, i, ii)) {
+                    ++numbers[i];
+                    soln[i + 1] |= BORDER(dir);
+                }
+            }
+        }
+    }
+
+    scopy(scratch_borders, rim, wh);
+    dsf_free(dsf);
+
+    return solver(dd->params, numbers, scratch_borders);
+}
+
 static char *new_game_desc(const game_params *params, random_state *rs,
                            char **aux, bool interactive)
 {
     int w = params->w, h = params->h, wh = w*h, k = params->k;
 
-    clue *numbers = snewn(wh + 1, clue);
-    borderflag *rim = snewn(wh, borderflag);
-    borderflag *scratch_borders = snewn(wh, borderflag);
+    desc_data dd = {params, rs, interactive, *aux};
+    initialise_desc_data(&dd);
+    game_desc_data *gdd = dd.game_desc_data;
 
-    char *soln = snewa(*aux, wh + 2);
-    int *shuf = snewn(wh, int);
-    DSF *dsf = NULL;
-    int i, r, c;
+    char *numbers = gdd->numbers;
+    borderflag *rim = gdd->rim;
+    borderflag *scratch_borders = gdd->scratch_borders;
 
-    for (i = 0; i < wh; ++i) shuf[i] = i;
-    xshuffle(shuf, wh, rs);
+    char *soln = gdd->soln;
+    int *shuf = gdd->shuf;
 
-    init_borders(w, h, rim);
+    while (!attempt_new_desc(&dd)) {}
 
-    assert (!('@' & BORDER_MASK));
-    *soln++ = 'S';
-    soln[wh] = '\0';
-
-    do {
-        setmem(soln, '@', wh);
-
-        dsf_free(dsf);
-        dsf = divvy_rectangle(w, h, k, rs);
-
-        for (r = 0; r < h; ++r)
-            for (c = 0; c < w; ++c) {
-                int i = r * w + c, dir;
-                numbers[i] = 0;
-                for (dir = 0; dir < 4; ++dir) {
-                    int rr = r + dy[dir], cc = c + dx[dir], ii = rr * w + cc;
-                    if (OUT_OF_BOUNDS(cc, rr, w, h) ||
-                        !dsf_equivalent(dsf, i, ii)) {
-                        ++numbers[i];
-                        soln[i] |= BORDER(dir);
-                    }
-                }
-            }
-
-        scopy(scratch_borders, rim, wh);
-    } while (!solver(params, numbers, scratch_borders));
-
-    for (i = 0; i < wh; ++i) {
+    for (int i = 0; i < wh; ++i) {
         int j = shuf[i];
         clue copy = numbers[j];
 
@@ -686,12 +733,11 @@ static char *new_game_desc(const game_params *params, random_state *rs,
     sfree(scratch_borders);
     sfree(rim);
     sfree(shuf);
-    dsf_free(dsf);
 
     char *output = snewn(wh + 1, char), *p = output;
 
-    r = 0;
-    for (i = 0; i < wh; ++i) {
+    int r = 0;
+    for (int i = 0; i < wh; ++i) {
         if (numbers[i] != EMPTY) {
             while (r) {
                 while (r > 26) {

--- a/puzzles.h
+++ b/puzzles.h
@@ -259,6 +259,7 @@ void new_game_started(drawing *dr);
 void new_game_finished(drawing *dr);
 typedef struct new_game_desc_args new_game_desc_args;
 void get_new_game_desc_async(midend *me, frontend *fe, new_game_desc_args *args);
+void new_game_attempt(void *arg, midend *me, new_game_desc_args *args, int attempts, bool solved);
 
 /*
  * drawing.c
@@ -325,7 +326,8 @@ game_params *midend_get_params(midend *me);
 void midend_size(midend *me, int *x, int *y, bool user_size,
                  double device_pixel_ratio);
 void midend_reset_tilesize(midend *me);
-char *get_new_game_desc(midend *me, new_game_desc_args *args);
+char *get_new_game_desc(midend *me, new_game_desc_args *args, bool iterative, void *iterative_arg);
+void new_game_async_attempt(midend *me, new_game_desc_args *args);
 void new_game_async_complete(midend *me, new_game_desc_args *args);
 void midend_new_game(midend *me);
 void midend_restart_game(midend *me);
@@ -771,6 +773,9 @@ struct game {
     bool is_timed;
     bool (*timing_state)(const game_state *state, game_ui *ui);
     int flags;
+    void (*initialise_desc_data)(desc_data *dd);
+    bool (*attempt_new_desc)(desc_data *dd);
+    void (*destroy_desc_data)(desc_data *dd, bool keep_outputs);
 };
 
 #define GET_HANDLE_AS_TYPE(dr, type) ((type*)((dr)->handle))

--- a/puzzles.h
+++ b/puzzles.h
@@ -91,6 +91,7 @@ enum {
 
 typedef struct frontend frontend;
 typedef struct config_item config_item;
+typedef enum Genmode Genmode;
 typedef struct midend midend;
 typedef struct random_state random_state;
 typedef struct game_params game_params;
@@ -256,6 +257,8 @@ void activate_timer(frontend *fe);
 void get_random_seed(void **randseed, int *randseedsize);
 void new_game_started(drawing *dr);
 void new_game_finished(drawing *dr);
+typedef struct new_game_desc_args new_game_desc_args;
+void get_new_game_desc_async(midend *me, frontend *fe, new_game_desc_args *args);
 
 /*
  * drawing.c
@@ -322,6 +325,8 @@ game_params *midend_get_params(midend *me);
 void midend_size(midend *me, int *x, int *y, bool user_size,
                  double device_pixel_ratio);
 void midend_reset_tilesize(midend *me);
+char *get_new_game_desc(midend *me, new_game_desc_args *args);
+void new_game_async_complete(midend *me, new_game_desc_args *args);
 void midend_new_game(midend *me);
 void midend_restart_game(midend *me);
 void midend_stop_anim(midend *me);

--- a/puzzles.h
+++ b/puzzles.h
@@ -676,6 +676,15 @@ void arraysort_fn(void *array, size_t nmemb, size_t size,
 #define arraysort(array, nmemb, cmp, ctx) \
     arraysort_fn(array, nmemb, sizeof(*(array)), cmp, ctx)
 
+typedef struct desc_data {
+    const game_params *params;
+    random_state *rs;
+    bool interactive;
+    char *aux;
+    char *desc;
+    void *game_desc_data;
+} desc_data;
+
 /*
  * Data structure containing the function calls and data specific
  * to a particular game. This is enclosed in a data structure so

--- a/puzzles.h
+++ b/puzzles.h
@@ -255,11 +255,10 @@ void frontend_default_colour(frontend *fe, float *output);
 void deactivate_timer(frontend *fe);
 void activate_timer(frontend *fe);
 void get_random_seed(void **randseed, int *randseedsize);
-void new_game_started(drawing *dr);
 void new_game_finished(drawing *dr);
 typedef struct new_game_desc_args new_game_desc_args;
 void get_new_game_desc_async(midend *me, frontend *fe, new_game_desc_args *args);
-void new_game_attempt(void *arg, midend *me, new_game_desc_args *args, int attempts, bool solved);
+bool new_game_attempt(void *arg, midend *me, new_game_desc_args *args, int attempts, bool solved);
 
 /*
  * drawing.c

--- a/puzzles.h
+++ b/puzzles.h
@@ -254,6 +254,8 @@ void frontend_default_colour(frontend *fe, float *output);
 void deactivate_timer(frontend *fe);
 void activate_timer(frontend *fe);
 void get_random_seed(void **randseed, int *randseedsize);
+void new_game_started(drawing *dr);
+void new_game_finished(drawing *dr);
 
 /*
  * drawing.c

--- a/windows.c
+++ b/windows.c
@@ -1473,6 +1473,8 @@ typedef struct get_new_game_desc_args {
     midend *me;
     frontend *fe;
     new_game_desc_args *args;
+    clock_t start_time;
+    clock_t last_display_time;
     int attempts;
     bool solved;
 } get_new_game_desc_args;
@@ -1635,6 +1637,8 @@ void get_new_game_desc_async(midend *me, frontend *fe, new_game_desc_args *args)
     thread_args->me = me;
     thread_args->fe = fe;
     thread_args->args = args;
+    thread_args->start_time = clock();
+    thread_args->last_display_time = 0;
     thread_args->attempts = 0;
     thread_args->solved = false;
     fe->current_thread_args = thread_args;
@@ -3354,10 +3358,16 @@ static LRESULT CALLBACK WndProc(HWND hwnd, UINT message,
 		case WM_NEW_GAME_ATTEMPT:
 		{
 			get_new_game_desc_args *thread_args = (get_new_game_desc_args*)wParam;
-			new_game_async_attempt(thread_args->me, thread_args->args);
-			char buf[64];
-			sprintf(buf, "Creating game, %d attempts so far...", thread_args->attempts);
-			SetWindowText(fe->stop_new_game_label, buf);
+	  		clock_t now = clock();
+	  		long display_time_diff_ms = (now - thread_args->last_display_time) * 1000 / CLOCKS_PER_SEC;
+	  	    if (display_time_diff_ms >= 500) {
+	  	    	thread_args->last_display_time = now;
+	  	    	new_game_async_attempt(thread_args->me, thread_args->args);
+	  	    	char buf[64];
+	  	    	sprintf(buf, "Creating game, %d seconds and %d attempts so far...",
+	  	    		(now - thread_args->start_time) / CLOCKS_PER_SEC, thread_args->attempts);
+	  	    	SetWindowText(fe->stop_new_game_label, buf);
+	  	    }
 			break;
 		}
     }

--- a/windows.c
+++ b/windows.c
@@ -60,6 +60,7 @@ char *help_path;
 bool help_has_contents;
 
 #define WM_NEW_GAME_COMPLETE (WM_APP + 1)
+#define WM_NEW_GAME_ATTEMPT (WM_APP + 2)
 
 #ifndef FILENAME_MAX
 #define	FILENAME_MAX	(260)
@@ -1568,12 +1569,28 @@ DWORD WINAPI control_new_game(void *arg)
     return 0;
 }
 
+typedef struct get_new_game_desc_args {
+    midend *me;
+    frontend *fe;
+    new_game_desc_args *args;
+    int attempts;
+    bool solved;
+} get_new_game_desc_args;
+
 void new_game_started(drawing *dr)
 {
     frontend *fe = GET_HANDLE_AS_TYPE(dr, frontend);
     EnableMenuItem(fe->gamemenu, IDM_NEW, MF_DISABLED);
     fe->stop_new_game_dialog_done = false;
     CreateThread(NULL, 0, control_new_game, fe, 0, NULL);
+}
+
+void new_game_attempt(void *arg, midend *me, new_game_desc_args *args, int attempts, bool solved)
+{
+	get_new_game_desc_args *thread_args = arg;
+	thread_args->attempts = attempts;
+	thread_args->solved = solved;
+	SendMessage(thread_args->fe->hwnd, WM_NEW_GAME_ATTEMPT, (WPARAM)thread_args, (LPARAM)NULL);
 }
 
 void new_game_finished(drawing *dr)
@@ -1586,19 +1603,13 @@ void new_game_finished(drawing *dr)
     }
 }
 
-typedef struct get_new_game_desc_args {
-    midend *me;
-    frontend *fe;
-    new_game_desc_args *args;
-} get_new_game_desc_args;
-
 DWORD WINAPI get_new_game_desc_thread(void *arg)
 {
     get_new_game_desc_args *thread_args = arg;
     new_game_desc_args *args = thread_args->args;
     midend *me = thread_args->me;
-    get_new_game_desc(me, args);
-    PostMessage(thread_args->fe->hwnd, WM_NEW_GAME_COMPLETE, (WPARAM)arg, (LPARAM)NULL);
+    get_new_game_desc(me, args, true, thread_args);
+    SendMessage(thread_args->fe->hwnd, WM_NEW_GAME_COMPLETE, (WPARAM)arg, (LPARAM)NULL);
     return 0;
 }
 
@@ -1608,6 +1619,8 @@ void get_new_game_desc_async(midend *me, frontend *fe, new_game_desc_args *args)
     thread_args->me = me;
     thread_args->fe = fe;
     thread_args->args = args;
+    thread_args->attempts = 0;
+    thread_args->solved = false;
     CreateThread(NULL, 0, get_new_game_desc_thread, thread_args, 0, NULL);
 }
 
@@ -3321,6 +3334,15 @@ static LRESULT CALLBACK WndProc(HWND hwnd, UINT message,
 		  sfree(thread_args);
 		  break;
 	  }
+		case WM_NEW_GAME_ATTEMPT:
+		{
+			get_new_game_desc_args *thread_args = (get_new_game_desc_args*)wParam;
+			new_game_async_attempt(thread_args->me, thread_args->args);
+			char buf[64];
+			sprintf(buf, "Creating game, %d attempts so far...", thread_args->attempts);
+			SetWindowText(fe->stop_new_game_label, buf);
+			break;
+		}
     }
 
     return DefWindowProc(hwnd, message, wParam, lParam);

--- a/windows.c
+++ b/windows.c
@@ -190,6 +190,9 @@ struct frontend {
     drawing *dr;
     int xmin, ymin;
     float puzz_scale;
+    HWND stop_new_game_window;
+    HWND stop_new_game_label;
+    bool stop_new_game_dialog_done;
 };
 
 void frontend_free(frontend *fe)
@@ -1419,6 +1422,10 @@ static frontend *frontend_new(HINSTANCE inst)
 
     SetWindowLongPtr(fe->hwnd, GWLP_USERDATA, (LONG_PTR)fe);
 
+    fe->stop_new_game_window = NULL;
+    fe->stop_new_game_label = NULL;
+    fe->stop_new_game_dialog_done = false;
+
     return fe;
 }
 
@@ -1435,6 +1442,146 @@ static bool savefile_read(void *wctx, void *buf, int len)
 
     ret = fread(buf, 1, len, fp);
     return (ret == len);
+}
+
+static int CALLBACK StopNewGameDlgProc(HWND hwnd, UINT msg,
+                 WPARAM wParam, LPARAM lParam)
+{
+    frontend *fe = (frontend *)GetWindowLongPtr(hwnd, GWLP_USERDATA);
+
+    switch (msg) {
+      case WM_INITDIALOG:
+        return 1;
+      case WM_CLOSE:
+        fe->stop_new_game_dialog_done = true;
+        return 0;
+    }
+
+    return 0;
+}
+
+static void make_stop_new_game_window(frontend *fe)
+{
+    WNDCLASS wc;
+    HDC hdc;
+    int winwidth, winheight;
+
+    wc.style = CS_DBLCLKS | CS_SAVEBITS;
+    wc.lpfnWndProc = DefDlgProc;
+    wc.cbClsExtra = 0;
+    wc.cbWndExtra = DLGWINDOWEXTRA + 8;
+    wc.hInstance = fe->inst;
+    wc.hIcon = NULL;
+    wc.hCursor = LoadCursor(NULL, IDC_ARROW);
+    wc.hbrBackground = (HBRUSH) (COLOR_BACKGROUND +1);
+    wc.lpszMenuName = NULL;
+    wc.lpszClassName = "GameStopNewGame";
+    RegisterClass(&wc);
+
+    hdc = GetDC(fe->hwnd);
+    SetMapMode(hdc, MM_TEXT);
+
+    // TODO: Is this OK to reuse this variable? It should be
+    fe->cfgfont = CreateFont(-MulDiv(8, GetDeviceCaps(hdc, LOGPIXELSY), 72),
+                 0, 0, 0, 0,
+                 false, false, false, DEFAULT_CHARSET,
+                 OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS,
+                 DEFAULT_QUALITY,
+                 FF_SWISS,
+                 "MS Shell Dlg");
+
+    winheight = 100;
+    winwidth = 200;
+
+    /*
+     * Create the dialog, now that we know its size.
+     */
+    {
+        RECT r, r2;
+
+        r.left = r.top = 0;
+        r.right = winwidth;
+        r.bottom = winheight;
+
+        AdjustWindowRectEx(&r, (WS_OVERLAPPEDWINDOW /*|
+                    DS_MODALFRAME | WS_POPUP | WS_VISIBLE |
+                    WS_CAPTION | WS_SYSMENU*/) &~
+                   (WS_MAXIMIZEBOX | WS_OVERLAPPED),
+                   false, 0);
+
+        /*
+         * Centre the dialog on its parent window.
+         */
+        r.right -= r.left;
+        r.bottom -= r.top;
+        GetWindowRect(fe->hwnd, &r2);
+        r.left = (r2.left + r2.right - r.right) / 2;
+        r.top = (r2.top + r2.bottom - r.bottom) / 2;
+        r.right += r.left;
+        r.bottom += r.top;
+
+        fe->stop_new_game_window = CreateWindowEx(
+            0, wc.lpszClassName, "Creating new game...",
+            DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU,
+            r.left, r.top, r.right-r.left, r.bottom-r.top,
+            fe->hwnd, NULL, fe->inst, NULL);
+    }
+
+    SendMessage(fe->stop_new_game_window, WM_SETFONT, (WPARAM)fe->cfgfont, false);
+
+    SetWindowLongPtr(fe->stop_new_game_window, GWLP_USERDATA, (LONG_PTR)fe);
+    SetWindowLongPtr(fe->stop_new_game_window, DWLP_DLGPROC, (LONG_PTR)StopNewGameDlgProc);
+
+    fe->stop_new_game_label = CreateWindowEx(0, "Static", "Creating new game...",
+             WS_CHILD | WS_VISIBLE, 10, 20, winwidth - 20, 30,
+             fe->stop_new_game_window, (HMENU)1000, fe->inst, NULL);
+    SendMessage(fe->stop_new_game_label, WM_SETFONT, (WPARAM)fe->cfgfont, MAKELPARAM(true, 0));
+
+    SendMessage(fe->stop_new_game_window, WM_INITDIALOG, 0, 0);
+
+    EnableWindow(fe->hwnd, false);
+    ShowWindow(fe->stop_new_game_window, SW_SHOWNORMAL);
+
+    MSG msg;
+    int gm;
+    while (!fe->stop_new_game_dialog_done && (gm = GetMessage(&msg, NULL, 0, 0)) > 0) {
+        if (!IsDialogMessage(fe->stop_new_game_window, &msg)) {
+            DispatchMessage(&msg);
+        }
+        if (fe->stop_new_game_dialog_done) {
+            fe->stop_new_game_dialog_done = false;
+            break;
+        }
+    }
+    EnableWindow(fe->hwnd, true);
+    SetForegroundWindow(fe->hwnd);
+    DestroyWindow(fe->stop_new_game_window);
+    DeleteObject(fe->cfgfont);
+}
+
+DWORD WINAPI control_new_game(void *arg)
+{
+    frontend *fe = arg;
+    make_stop_new_game_window(fe);
+    return 0;
+}
+
+void new_game_started(drawing *dr)
+{
+    frontend *fe = GET_HANDLE_AS_TYPE(dr, frontend);
+    EnableMenuItem(fe->gamemenu, IDM_NEW, MF_DISABLED);
+    fe->stop_new_game_dialog_done = false;
+    CreateThread(NULL, 0, control_new_game, fe, 0, NULL);
+}
+
+void new_game_finished(drawing *dr)
+{
+    frontend *fe = GET_HANDLE_AS_TYPE(dr, frontend);
+    EnableMenuItem(fe->gamemenu, IDM_NEW, MF_ENABLED);
+    fe->stop_new_game_dialog_done = true;
+    if (fe->stop_new_game_window) {
+        SendMessage(fe->stop_new_game_window, WM_CLOSE, 0, 0);
+    }
 }
 
 /*

--- a/windows.c
+++ b/windows.c
@@ -1449,17 +1449,21 @@ static bool savefile_read(void *wctx, void *buf, int len)
     return (ret == len);
 }
 
-static int CALLBACK StopNewGameDlgProc(HWND hwnd, UINT msg,
-                 WPARAM wParam, LPARAM lParam)
+static int CALLBACK StopNewGameDlgProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
     frontend *fe = (frontend *)GetWindowLongPtr(hwnd, GWLP_USERDATA);
 
     switch (msg) {
-      case WM_INITDIALOG:
-        return 1;
-      case WM_CLOSE:
-        fe->stop_new_game_dialog_done = true;
-        return 0;
+        case WM_INITDIALOG:
+            return 1;
+        case WM_COMMAND:
+            if (LOWORD(wParam) == IDOK) {
+                fe->stop_new_game_dialog_done = true;
+            }
+            break;
+        case WM_CLOSE:
+            fe->stop_new_game_dialog_done = true;
+            break;
     }
 
     return 0;
@@ -1552,6 +1556,12 @@ static void make_stop_new_game_window(get_new_game_desc_args *thread_args)
              WS_CHILD | WS_VISIBLE, 10, 20, winwidth - 20, 30,
              fe->stop_new_game_window, (HMENU)1000, fe->inst, NULL);
     SendMessage(fe->stop_new_game_label, WM_SETFONT, (WPARAM)fe->cfgfont, MAKELPARAM(true, 0));
+
+    HWND button = CreateWindowEx(0, "BUTTON", "Stop",
+BS_PUSHBUTTON | WS_TABSTOP | BS_DEFPUSHBUTTON | WS_CHILD | WS_VISIBLE,
+        10, 60, winwidth - 20, 30,
+        fe->stop_new_game_window, (HMENU)IDOK, fe->inst, NULL);
+    SendMessage(button, WM_SETFONT, (WPARAM)fe->cfgfont, MAKELPARAM(true, 0));
 
     SendMessage(fe->stop_new_game_window, WM_INITDIALOG, 0, 0);
 

--- a/windows.c
+++ b/windows.c
@@ -59,6 +59,8 @@ enum { NONE, HLP, CHM } help_type;
 char *help_path;
 bool help_has_contents;
 
+#define WM_NEW_GAME_COMPLETE (WM_APP + 1)
+
 #ifndef FILENAME_MAX
 #define	FILENAME_MAX	(260)
 #endif
@@ -1582,6 +1584,31 @@ void new_game_finished(drawing *dr)
     if (fe->stop_new_game_window) {
         SendMessage(fe->stop_new_game_window, WM_CLOSE, 0, 0);
     }
+}
+
+typedef struct get_new_game_desc_args {
+    midend *me;
+    frontend *fe;
+    new_game_desc_args *args;
+} get_new_game_desc_args;
+
+DWORD WINAPI get_new_game_desc_thread(void *arg)
+{
+    get_new_game_desc_args *thread_args = arg;
+    new_game_desc_args *args = thread_args->args;
+    midend *me = thread_args->me;
+    get_new_game_desc(me, args);
+    PostMessage(thread_args->fe->hwnd, WM_NEW_GAME_COMPLETE, (WPARAM)arg, (LPARAM)NULL);
+    return 0;
+}
+
+void get_new_game_desc_async(midend *me, frontend *fe, new_game_desc_args *args)
+{
+    get_new_game_desc_args *thread_args = snew(get_new_game_desc_args);
+    thread_args->me = me;
+    thread_args->fe = fe;
+    thread_args->args = args;
+    CreateThread(NULL, 0, get_new_game_desc_thread, thread_args, 0, NULL);
 }
 
 /*
@@ -3287,6 +3314,13 @@ static LRESULT CALLBACK WndProc(HWND hwnd, UINT message,
             return true;
         }
         break;
+	  case WM_NEW_GAME_COMPLETE:
+	  {
+		  get_new_game_desc_args *thread_args = (get_new_game_desc_args *)wParam;
+		  new_game_async_complete(thread_args->me, thread_args->args);
+		  sfree(thread_args);
+		  break;
+	  }
     }
 
     return DefWindowProc(hwnd, message, wParam, lParam);

--- a/windows.c
+++ b/windows.c
@@ -196,6 +196,7 @@ struct frontend {
     HWND stop_new_game_window;
     HWND stop_new_game_label;
     bool stop_new_game_dialog_done;
+    void *current_thread_args;
 };
 
 void frontend_free(frontend *fe)
@@ -1428,6 +1429,7 @@ static frontend *frontend_new(HINSTANCE inst)
     fe->stop_new_game_window = NULL;
     fe->stop_new_game_label = NULL;
     fe->stop_new_game_dialog_done = false;
+    fe->current_thread_args = NULL;
 
     return fe;
 }
@@ -1463,8 +1465,19 @@ static int CALLBACK StopNewGameDlgProc(HWND hwnd, UINT msg,
     return 0;
 }
 
-static void make_stop_new_game_window(frontend *fe)
+typedef struct get_new_game_desc_args {
+    midend *me;
+    frontend *fe;
+    new_game_desc_args *args;
+    int attempts;
+    bool solved;
+} get_new_game_desc_args;
+
+DWORD WINAPI get_new_game_desc_thread(void *arg);
+
+static void make_stop_new_game_window(get_new_game_desc_args *thread_args)
 {
+    frontend *fe = thread_args->fe;
     WNDCLASS wc;
     HDC hdc;
     int winwidth, winheight;
@@ -1544,6 +1557,9 @@ static void make_stop_new_game_window(frontend *fe)
 
     EnableWindow(fe->hwnd, false);
     ShowWindow(fe->stop_new_game_window, SW_SHOWNORMAL);
+    EnableMenuItem(fe->gamemenu, IDM_NEW, MF_DISABLED);
+
+    CreateThread(NULL, 0, get_new_game_desc_thread, thread_args, 0, NULL);
 
     MSG msg;
     int gm;
@@ -1552,51 +1568,41 @@ static void make_stop_new_game_window(frontend *fe)
             DispatchMessage(&msg);
         }
         if (fe->stop_new_game_dialog_done) {
-            fe->stop_new_game_dialog_done = false;
             break;
         }
     }
     EnableWindow(fe->hwnd, true);
     SetForegroundWindow(fe->hwnd);
     DestroyWindow(fe->stop_new_game_window);
+    fe->stop_new_game_window = NULL;
+    fe->stop_new_game_label = NULL;
+    fe->stop_new_game_dialog_done = false;
+    fe->current_thread_args = NULL;
     DeleteObject(fe->cfgfont);
+    EnableMenuItem(fe->gamemenu, IDM_NEW, MF_ENABLED);
 }
 
-DWORD WINAPI control_new_game(void *arg)
+DWORD WINAPI control_new_game(get_new_game_desc_args *thread_args)
 {
-    frontend *fe = arg;
-    make_stop_new_game_window(fe);
+    make_stop_new_game_window(thread_args);
     return 0;
 }
 
-typedef struct get_new_game_desc_args {
-    midend *me;
-    frontend *fe;
-    new_game_desc_args *args;
-    int attempts;
-    bool solved;
-} get_new_game_desc_args;
-
-void new_game_started(drawing *dr)
-{
-    frontend *fe = GET_HANDLE_AS_TYPE(dr, frontend);
-    EnableMenuItem(fe->gamemenu, IDM_NEW, MF_DISABLED);
-    fe->stop_new_game_dialog_done = false;
-    CreateThread(NULL, 0, control_new_game, fe, 0, NULL);
-}
-
-void new_game_attempt(void *arg, midend *me, new_game_desc_args *args, int attempts, bool solved)
+bool new_game_attempt(void *arg, midend *me, new_game_desc_args *args, int attempts, bool solved)
 {
 	get_new_game_desc_args *thread_args = arg;
+	if (thread_args->fe->current_thread_args != thread_args) {
+		return false;
+	}
 	thread_args->attempts = attempts;
 	thread_args->solved = solved;
 	SendMessage(thread_args->fe->hwnd, WM_NEW_GAME_ATTEMPT, (WPARAM)thread_args, (LPARAM)NULL);
+	return true;
 }
 
 void new_game_finished(drawing *dr)
 {
     frontend *fe = GET_HANDLE_AS_TYPE(dr, frontend);
-    EnableMenuItem(fe->gamemenu, IDM_NEW, MF_ENABLED);
     fe->stop_new_game_dialog_done = true;
     if (fe->stop_new_game_window) {
         SendMessage(fe->stop_new_game_window, WM_CLOSE, 0, 0);
@@ -1621,7 +1627,8 @@ void get_new_game_desc_async(midend *me, frontend *fe, new_game_desc_args *args)
     thread_args->args = args;
     thread_args->attempts = 0;
     thread_args->solved = false;
-    CreateThread(NULL, 0, get_new_game_desc_thread, thread_args, 0, NULL);
+    fe->current_thread_args = thread_args;
+    CreateThread(NULL, 0, control_new_game, thread_args, 0, NULL);
 }
 
 /*

--- a/windows.c
+++ b/windows.c
@@ -1449,13 +1449,31 @@ static bool savefile_read(void *wctx, void *buf, int len)
     return (ret == len);
 }
 
+typedef struct get_new_game_desc_args {
+    midend *me;
+    frontend *fe;
+    new_game_desc_args *args;
+    clock_t start_time;
+    clock_t last_display_time;
+    int attempts;
+    bool solved;
+} get_new_game_desc_args;
+
 static int CALLBACK StopNewGameDlgProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
-    frontend *fe = (frontend *)GetWindowLongPtr(hwnd, GWLP_USERDATA);
+    get_new_game_desc_args *thread_args = (get_new_game_desc_args *)GetWindowLongPtr(hwnd, GWLP_USERDATA);
+    frontend *fe = thread_args->fe;
 
     switch (msg) {
         case WM_INITDIALOG:
             return 1;
+        case WM_TIMER:
+            clock_t now = clock();
+            char buf[64];
+            sprintf(buf, "Creating game, %d seconds and %d attempts so far...",
+                    (now - thread_args->start_time) / CLOCKS_PER_SEC, thread_args->attempts);
+            SetWindowText(fe->stop_new_game_label, buf);
+            break;
         case WM_COMMAND:
             if (LOWORD(wParam) == IDOK) {
                 fe->stop_new_game_dialog_done = true;
@@ -1468,16 +1486,6 @@ static int CALLBACK StopNewGameDlgProc(HWND hwnd, UINT msg, WPARAM wParam, LPARA
 
     return 0;
 }
-
-typedef struct get_new_game_desc_args {
-    midend *me;
-    frontend *fe;
-    new_game_desc_args *args;
-    clock_t start_time;
-    clock_t last_display_time;
-    int attempts;
-    bool solved;
-} get_new_game_desc_args;
 
 DWORD WINAPI get_new_game_desc_thread(void *arg);
 
@@ -1551,7 +1559,7 @@ static void make_stop_new_game_window(get_new_game_desc_args *thread_args)
 
     SendMessage(fe->stop_new_game_window, WM_SETFONT, (WPARAM)fe->cfgfont, false);
 
-    SetWindowLongPtr(fe->stop_new_game_window, GWLP_USERDATA, (LONG_PTR)fe);
+    SetWindowLongPtr(fe->stop_new_game_window, GWLP_USERDATA, (LONG_PTR)thread_args);
     SetWindowLongPtr(fe->stop_new_game_window, DWLP_DLGPROC, (LONG_PTR)StopNewGameDlgProc);
 
     fe->stop_new_game_label = CreateWindowEx(0, "Static", "Creating new game...",
@@ -1572,6 +1580,7 @@ BS_PUSHBUTTON | WS_TABSTOP | BS_DEFPUSHBUTTON | WS_CHILD | WS_VISIBLE,
     EnableMenuItem(fe->gamemenu, IDM_NEW, MF_DISABLED);
 
     CreateThread(NULL, 0, get_new_game_desc_thread, thread_args, 0, NULL);
+    UINT_PTR timer = SetTimer(fe->stop_new_game_window, 1, 5000, NULL);
 
     MSG msg;
     int gm;
@@ -1585,6 +1594,7 @@ BS_PUSHBUTTON | WS_TABSTOP | BS_DEFPUSHBUTTON | WS_CHILD | WS_VISIBLE,
     }
     EnableWindow(fe->hwnd, true);
     SetForegroundWindow(fe->hwnd);
+    KillTimer(fe->stop_new_game_window, timer);
     DestroyWindow(fe->stop_new_game_window);
     fe->stop_new_game_window = NULL;
     fe->stop_new_game_label = NULL;


### PR DESCRIPTION
When creating a bigger puzzle in some games it takes a very long time to find a solution and the window seems apparently frozen.

This splits game description generation in 3 parts:

* Initialise variables
* Make a new attempt to create a game description
* Destroy variables

We can now show the progress to the user, and allow them to stop the game generation if it's taking too long.

![image](https://github.com/user-attachments/assets/6782e55d-9aad-4a01-acd7-30bc62b4d7a1)

For the purposes of brevity only one game is updated to provide this functionality, and the rest of the games are in PR #5 